### PR TITLE
feat: configure drizzle with users table

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -1,0 +1,6 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from './schema';
+
+const sqlite = new Database('local.db');
+export const db = drizzle(sqlite, { schema });

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,11 +1,7 @@
-// This is where you can define your database schema using Drizzle ORM.
-// For example:
-//
-// import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-//
-// export const users = sqliteTable('users', {
-//   id: integer('id').primaryKey(),
-//   fullName: text('full_name'),
-// });
-//
-// See Drizzle ORM documentation for more details: https://orm.drizzle.team/docs/overview
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  username: text('username').notNull().unique(),
+  password: text('password').notNull(),
+});

--- a/drizzle/0000_lush_mikhail_rasputin.sql
+++ b/drizzle/0000_lush_mikhail_rasputin.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`username` text NOT NULL,
+	`password` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,55 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "53da7f9b-9772-49fe-a3c5-a594f168f013",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1756915540490,
+      "tag": "0000_lush_mikhail_rasputin",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@socialgouv/matomo-next": "^1.9.2",
+    "better-sqlite3": "^9.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- add sqlite drizzle client with better-sqlite3
- define users table schema and create migration
- include better-sqlite3 dependency

## Testing
- `npm install better-sqlite3` *(fails: 403 Forbidden)*
- `npm run lint` *(plugin recommendation output)*

------
https://chatgpt.com/codex/tasks/task_e_68b86693288c832a90f66a6d695646d9