### PR TITLE
Centralize session state handling with global store

### DIFF
--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -1,45 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-
-interface Faction {
-    id: number;
-    name: string;
-    color: string | null;
-    access_rank: number | null;
-    moderation_rank: number | null;
-    feature_flags: {
-        activity_rosters_enabled?: boolean;
-        character_sheets_enabled?: boolean;
-    } | null;
-}
-interface Session {
-  isLoggedIn: boolean;
-  username?: string;
-  role?: string;
-  hasActiveFaction?: boolean;
-  activeFaction?: Faction | null;
-}
+import { useSessionStore } from '@/stores/session-store';
 
 export function useSession() {
-  const [session, setSession] = useState<Session | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const pathname = usePathname();
-
-  const fetchSession = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch('/api/auth/session');
-      const data = await response.json();
-      setSession(data);
-    } catch (error) {
-      console.error('Failed to fetch session', error);
-      setSession({ isLoggedIn: false, hasActiveFaction: false });
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const { session, isLoading, fetchSession } = useSessionStore();
 
   useEffect(() => {
     fetchSession();

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { create } from 'zustand';
+
+interface Faction {
+  id: number;
+  name: string;
+  color: string | null;
+  access_rank: number | null;
+  moderation_rank: number | null;
+  feature_flags: {
+    activity_rosters_enabled?: boolean;
+    character_sheets_enabled?: boolean;
+  } | null;
+}
+
+interface Session {
+  isLoggedIn: boolean;
+  username?: string;
+  role?: string;
+  hasActiveFaction?: boolean;
+  activeFaction?: Faction | null;
+}
+
+interface SessionState {
+  session: Session | null;
+  isLoading: boolean;
+  fetchSession: () => Promise<void>;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+  session: null,
+  isLoading: true,
+  fetchSession: async () => {
+    set({ isLoading: true });
+    try {
+      const response = await fetch('/api/auth/session', { cache: 'no-store' });
+      const data = await response.json();
+      set({ session: data });
+    } catch (error) {
+      console.error('Failed to fetch session', error);
+      set({ session: { isLoggedIn: false, hasActiveFaction: false } });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+


### PR DESCRIPTION
## Summary
- add a Zustand-powered session store
- refactor useSession hook to share state across components

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next-themes/dist/types' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5422da9c8832aa73160b93147c10a