### PR TITLE
Replace MySQL connection URL with separate env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@
 
 Select the database backend by setting the `DATABASE` variable in your `.env` file. Supported values are `sqlite`, `mysql`, and `mariadb`.
 
-When using SQLite, the optional `DB_FILE_NAME` sets the file location. For MySQL or MariaDB, provide a connection string via `DB_URL`.
+When using SQLite, the optional `DB_FILE_NAME` sets the file location. For MySQL or MariaDB, configure the following variables instead of a single connection string:
+
+- `DB_IP` (defaults to `127.0.0.1`)
+- `DB_PORT` (defaults to `3306`)
+- `DB_NAME`
+- `DB_USERNAME`
+- `DB_PASSWORD`

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
   dialect: dbType === 'sqlite' ? 'sqlite' : 'mysql',
   dbCredentials: dbType === 'sqlite'
     ? { url: `file:${dbFile}` }
-    : { url: process.env.DB_URL! },
+    : {
+        url: `mysql://${process.env.DB_USERNAME!}:${process.env.DB_PASSWORD!}` +
+          `@${process.env.DB_IP ?? '127.0.0.1'}:${process.env.DB_PORT ?? '3306'}/${process.env.DB_NAME!}`,
+      },
   strict: true,
   verbose: true,
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,7 +11,13 @@ const dbType = process.env.DATABASE ?? 'sqlite';
 let dbInstance: any;
 
 if (dbType === 'mysql' || dbType === 'mariadb') {
-  const pool = mysql.createPool(process.env.DB_URL!);
+  const pool = mysql.createPool({
+    host: process.env.DB_IP ?? '127.0.0.1',
+    port: Number(process.env.DB_PORT ?? '3306'),
+    user: process.env.DB_USERNAME!,
+    password: process.env.DB_PASSWORD!,
+    database: process.env.DB_NAME!,
+  });
   dbInstance = drizzleMysql(pool, { schema });
 } else {
   const envPath = process.env.DB_FILE_NAME;


### PR DESCRIPTION
## Summary
- Replace `DB_URL` with individual MySQL connection settings (`DB_IP`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`)
- Generate MySQL connection URL in drizzle config from separate environment variables
- Document new MySQL environment variables and defaults in README

## Testing
- `npm run lint` *(fails: Unexpected any in src/db/index.ts and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a708c7f4832a923ef619e0ee76d3