### PR TITLE
Allow moving members to any unit or detail

### DIFF
--- a/src/components/units-divisions/cat3-members-table.tsx
+++ b/src/components/units-divisions/cat3-members-table.tsx
@@ -150,7 +150,9 @@ export function Cat3MembersTable({ members, allFactionMembers, allAssignedCharac
                 onSuccess={onDataChange}
                 member={movingMember}
                 sourceCat2Id={cat2Id}
-                allUnitsAndDetails={allUnitsAndDetails.filter(opt => opt.value !== cat3Id.toString())}
+                allUnitsAndDetails={allUnitsAndDetails.filter(
+                    opt => !(opt.type === 'cat_3' && opt.value === cat3Id.toString())
+                )}
             />
             <Card>
                 <CardHeader>

--- a/src/components/units-divisions/members-table.tsx
+++ b/src/components/units-divisions/members-table.tsx
@@ -148,7 +148,9 @@ export function MembersTable({ members, allFactionMembers, allAssignedCharacterI
             onSuccess={onDataChange}
             member={movingMember}
             sourceCat2Id={cat2Id}
-            allUnitsAndDetails={allUnitsAndDetails.filter(opt => opt.value !== cat2Id.toString())}
+            allUnitsAndDetails={allUnitsAndDetails.filter(
+                opt => !(opt.type === 'cat_2' && opt.value === cat2Id.toString())
+            )}
         />
         <Card>
             <CardHeader>


### PR DESCRIPTION
## Summary
- Refine member move options to exclude only the current unit and keep all other units/details available
- Do the same for detail member movements so any unit or detail in the faction can be chosen

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c7abc804fc832abc8b13d78d56523d