### PR TITLE
Fix setup superadmin not updating DB

### DIFF
--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -62,13 +62,18 @@ export async function POST(request: NextRequest) {
         tx
           .update(users)
           .set({ role: 'superadmin' })
-          .where(eq(users.id, session.userId!));
+          .where(eq(users.id, session.userId!))
+          .run();
 
         // Mark setup as complete
-        tx.insert(setup).values({ completed: true }).onConflictDoUpdate({
-          target: setup.completed,
-          set: { completed: true },
-        });
+        tx
+          .insert(setup)
+          .values({ completed: true })
+          .onConflictDoUpdate({
+            target: setup.completed,
+            set: { completed: true },
+          })
+          .run();
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure SQLite transactions in `/api/setup` run queries so the user gains superadmin role in the database

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c810ecf5c8832aa37e80abe6238038