### PR TITLE
Fix setup transaction error

### DIFF
--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -41,21 +41,23 @@ export async function POST(request: NextRequest) {
     }
 
     // Use a transaction to ensure both operations succeed or fail together.
-    await db.transaction(async (tx) => {
+    db.transaction((tx) => {
       // Grant superadmin role
-      await tx
+      tx
         .update(users)
         .set({ role: 'superadmin' })
-        .where(eq(users.id, session.userId!));
+        .where(eq(users.id, session.userId!))
+        .run();
 
       // Mark setup as complete
-      await tx
+      tx
         .insert(setup)
         .values({ completed: true })
         .onConflictDoUpdate({
           target: setup.completed,
           set: { completed: true },
-        });
+        })
+        .run();
     });
 
     // Update the session with the new role


### PR DESCRIPTION
## Summary
- handle setup transaction synchronously to avoid returning a promise

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c814ae4318832a8a897720afdc53be