### PR TITLE
feat: add delete sync data functionality

### DIFF
--- a/src/app/api/sync-management/delete/route.ts
+++ b/src/app/api/sync-management/delete/route.ts
@@ -1,0 +1,56 @@
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/session';
+import { db } from '@/db';
+import { factionMembersCache } from '@/db/schema/factionMembersCache';
+import { factionMembersAbasCache } from '@/db/schema/factionMembersAbasCache';
+import { forumApiCache } from '@/db/schema/forumApiCache';
+import { apiCacheAlternativeCharacters } from '@/db/schema/apiCacheAlternativeCharacters';
+import { factionAuditLogs } from '@/db/schema/auditLogs';
+import { eq } from 'drizzle-orm';
+
+export async function DELETE(request: NextRequest) {
+    try {
+        const session = await getSession(request.cookies);
+        if (!session.isLoggedIn || !session.userId) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const user = await db.query.users.findFirst({
+            where: (users, { eq }) => eq(users.id, session.userId!),
+            with: {
+                selectedFaction: true,
+            }
+        });
+
+        if (!user || !user.selectedFaction) {
+             return NextResponse.json({ error: 'No active faction selected.' }, { status: 400 });
+        }
+
+        const factionId = user.selectedFaction.id;
+
+        // Delete data from caches
+        await db.delete(factionMembersCache).where(eq(factionMembersCache.faction_id, factionId));
+        await db.delete(factionMembersAbasCache).where(eq(factionMembersAbasCache.faction_id, factionId));
+        await db.delete(forumApiCache).where(eq(forumApiCache.faction_id, factionId));
+        await db.delete(apiCacheAlternativeCharacters).where(eq(apiCacheAlternativeCharacters.faction_id, factionId));
+
+        // Log the action
+        await db.insert(factionAuditLogs).values({
+            faction_id: factionId,
+            user_id: session.userId,
+            category: 'sync_management',
+            action: 'delete_data',
+            details: {
+                timestamp: new Date().toISOString(),
+                user_agent: request.headers.get('user-agent'),
+            }
+        });
+
+        return NextResponse.json({ message: 'Sync data deleted successfully.' });
+
+    } catch (error: any) {
+        console.error('Error deleting sync data:', error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/src/components/sync-management/sync-management-client-page.tsx
+++ b/src/components/sync-management/sync-management-client-page.tsx
@@ -5,7 +5,18 @@ import { useEffect, useState } from 'react';
 import { PageHeader } from '@/components/dashboard/page-header';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertTriangle, Loader2, RefreshCw, Users, Activity, MessageSquare, Check, X, ArrowRight, Save, ArrowLeft } from 'lucide-react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+  } from '@/components/ui/alert-dialog';
+import { AlertTriangle, Loader2, RefreshCw, Users, Activity, MessageSquare, Check, X, ArrowRight, Save, ArrowLeft, Trash } from 'lucide-react';
 import { Skeleton } from '../ui/skeleton';
 import { useSession } from '@/hooks/use-session';
 import { Button } from '../ui/button';
@@ -215,6 +226,23 @@ export function SyncManagementClientPage() {
             setIsLoading(false);
         }
     }
+
+    const handleDeleteData = async () => {
+        setIsLoading(true);
+        try {
+            const res = await fetch('/api/sync-management/delete', {
+                method: 'DELETE',
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error);
+            toast({ title: 'Success', description: data.message });
+            await fetchStatus();
+        } catch (err: any) {
+            toast({ variant: 'destructive', title: 'Delete Failed', description: err.message });
+        } finally {
+            setIsLoading(false);
+        }
+    }
     
     const handleDiscard = () => {
         setPreviewing(null);
@@ -313,6 +341,37 @@ export function SyncManagementClientPage() {
                                 </CardContent>
                             </Card>
                         )}
+
+                        <Card className="border-destructive/50">
+                            <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-destructive"><AlertTriangle /> Danger Zone</CardTitle>
+                                <CardDescription>Manage destructive actions for your sync data.</CardDescription>
+                            </CardHeader>
+                            <CardContent className="flex items-center justify-between">
+                                <div>
+                                    <p className="font-semibold">Delete Sync Data</p>
+                                    <p className="text-sm text-muted-foreground">Permanently delete all synced data. This acts as a hard reset for corrupted data.</p>
+                                </div>
+                                <AlertDialog>
+                                    <AlertDialogTrigger asChild>
+                                        <Button variant="destructive"><Trash className="mr-2 h-4 w-4"/> Delete Data</Button>
+                                    </AlertDialogTrigger>
+                                    <AlertDialogContent>
+                                        <AlertDialogHeader>
+                                            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                                            <AlertDialogDescription>
+                                                This action cannot be undone. This will permanently delete all synced data (members, ABAS, forum cache) for your faction.
+                                                You will need to re-sync all data manually.
+                                            </AlertDialogDescription>
+                                        </AlertDialogHeader>
+                                        <AlertDialogFooter>
+                                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                            <AlertDialogAction onClick={handleDeleteData} className="bg-destructive hover:bg-destructive/90">Delete Data</AlertDialogAction>
+                                        </AlertDialogFooter>
+                                    </AlertDialogContent>
+                                </AlertDialog>
+                            </CardContent>
+                        </Card>
                     </>
                 ) : null}
             </div>


### PR DESCRIPTION
Added a "Delete Data" button to the Sync Management page to allow users to wipe all synced data (members, ABAS, forum cache) for their faction. This provides a way to fix corrupted data by performing a hard reset.

- Added DELETE /api/sync-management/delete endpoint.
- Updated SyncManagementClientPage to include a "Danger Zone" with the delete button and confirmation dialog.
- Added audit logging for the delete action.